### PR TITLE
Fix repo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before installing the theme, ensure you have the following:
 1. **Clone the Repository:**
 
    ```sh
-   git clone https://github.com/yourusername/TokyoNight-XcodeTheme.git
+   git clone https://github.com/tornikegomareli/TokyoNight-XcodeTheme.git
    cd TokyoNight-XcodeTheme
    ```
 


### PR DESCRIPTION
I noticed this while trying to set up the theme. The git link in the readme was quicker to copy :)